### PR TITLE
建置：重新設計建置命令以改善相容性

### DIFF
--- a/lua/dast/plugins/telescope.lua
+++ b/lua/dast/plugins/telescope.lua
@@ -3,7 +3,7 @@ return {
   branch = "0.1.x",
   dependencies = {
     "nvim-lua/plenary.nvim",
-    { "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
+    { "nvim-telescope/telescope-fzf-native.nvim", build = "zig" },
     "nvim-tree/nvim-web-devicons",
     "folke/todo-comments.nvim",
   },


### PR DESCRIPTION
- 將`nvim-telescope/telescope-fzf-native.nvim`的建置命令從`make`更改為`zig`

Signed-off-by: OfficePC <jackie@dast.tw>
