### PR TITLE
特性: 重構代碼格式並添加對 `folke/trouble.nvim` 插件的配置

### DIFF
--- a/lua/dast/plugins/formatting.lua
+++ b/lua/dast/plugins/formatting.lua
@@ -9,7 +9,7 @@ return {
         markdown = { "prettier" },
         json = { "prettier" },
         bash = { "shellcheck" },
-        sh = { "shellcheck" },
+        sh = { "shfmt" },
         yaml = { "prettier" },
         lua = { "stylua" },
         python = { "isort", "black" },

--- a/lua/dast/plugins/trouble.lua
+++ b/lua/dast/plugins/trouble.lua
@@ -1,0 +1,12 @@
+return {
+  "folke/trouble.nvim",
+  dependencies = { "nvim-tree/nvim-web-devicons", "folke/todo-comments.nvim" },
+  keys = {
+    { "<leader>xx", "<cmd>TroubleToggle<CR>", desc = "Open/close trouble list" },
+    { "<leader>xw", "<cmd>TroubleToggle workspace_diagnostics<CR>", desc = "Open trouble workspace diagnostics" },
+    { "<leader>xd", "<cmd>TroubleToggle document_diagnostics<CR>", desc = "Open trouble document diagnostics" },
+    { "<leader>xq", "<cmd>TroubleToggle quickfix<CR>", desc = "Open trouble quickfix list" },
+    { "<leader>xl", "<cmd>TroubleToggle loclist<CR>", desc = "Open trouble location list" },
+    { "<leader>xt", "<cmd>TodoTrouble<CR>", desc = "Open todos in trouble" },
+  },
+}


### PR DESCRIPTION
- 將 `sh` 的代碼格式化工具從 `shellcheck` 更新為 `shfmt`
- 添加一個與 `folke/trouble.nvim` 插件相關的配置文件 `trouble.lua`

Signed-off-by: OfficePC <jackie@dast.tw>
