### PR TITLE
GIT COMMIT MESSAGE:

### DIFF
--- a/lua/dast/plugins/formatting.lua
+++ b/lua/dast/plugins/formatting.lua
@@ -13,7 +13,6 @@ return {
         yaml = { "prettier" },
         lua = { "stylua" },
         python = { "isort", "black" },
-        zsh = { "beautysh" },
       },
       format_on_save = {
         lsp_fallback = true,

--- a/lua/dast/plugins/linting.lua
+++ b/lua/dast/plugins/linting.lua
@@ -8,7 +8,6 @@ return {
       python = { "pylint" },
       bash = { "shellcheck" },
       sh = { "shellcheck" },
-      zsh = { "beautysh" },
     }
 
     local lint_augroup = vim.api.nvim_create_augroup("lint", { clear = true })

--- a/lua/dast/plugins/lsp/lspconfig.lua
+++ b/lua/dast/plugins/lsp/lspconfig.lua
@@ -84,21 +84,6 @@ return {
           capabilities = capabilities,
         })
       end,
-      ["svelte"] = function()
-        -- configure svelte server
-        lspconfig["svelte"].setup({
-          capabilities = capabilities,
-          on_attach = function(client, bufnr)
-            vim.api.nvim_create_autocmd("BufWritePost", {
-              pattern = { "*.js", "*.ts" },
-              callback = function(ctx)
-                -- Here use ctx.match instead of ctx.file
-                client.notify("$/onDidChangeTsOrJsFile", { uri = ctx.match })
-              end,
-            })
-          end,
-        })
-      end,
       ["bashls"] = function()
         -- configure lua server (with special settings)
         lspconfig["bashls"].setup({

--- a/lua/dast/plugins/lsp/mason.lua
+++ b/lua/dast/plugins/lsp/mason.lua
@@ -43,7 +43,6 @@ return {
         "stylua", -- An opinionated Lua code formatter.
         "isort", -- isort is a Python utility / library to sort imports alphabetically.
         "shfmt", -- A shell formatter (sh/bash/mksh).
-        "beautysh",
       },
     })
   end,


### PR DESCRIPTION
重構：重構插件配置和工具列表

- 從 `formatting.lua` 中的格式化插件列表中刪除 `zsh` 項目
- 從 `linting.lua` 中的 linting 工具列表中刪除 `zsh` 項目
- 在 `lspconfig.lua` 中刪除 `svelte` 的自定義設置
- 從 `mason.lua` 中的工具列表中刪除 `beautysh`

Signed-off-by: HomePC <jackie@dast.tw>
