### PR TITLE
功能: 整合 `noice.nvim` 插件設定

### DIFF
--- a/lua/dast/plugins/noice.lua
+++ b/lua/dast/plugins/noice.lua
@@ -1,0 +1,22 @@
+return {
+  "folke/noice.nvim",
+  event = "VeryLazy",
+  opts = {
+    -- add any options here
+    routes = {
+      {
+        filter = { event = "notify", find = "No Information available" },
+        opts = { skip = true },
+      },
+    },
+    presets = {
+      lsp_doc_border = true,
+    },
+  },
+  dependencies = {
+    "MunifTanjim/nui.nvim",
+    "rcarriga/nvim-notify",
+  },
+  -- Dismiss Noice Message
+  vim.keymap.set("n", "<leader>nd", "<cmd>NoiceDismiss<CR>", { desc = "Dismiss Noice Message" }),
+}

--- a/lua/dast/plugins/treesitter.lua
+++ b/lua/dast/plugins/treesitter.lua
@@ -40,6 +40,7 @@ return {
         "json",
         "yaml",
         "dockerfile",
+        "regex",
       },
       incremental_selection = {
         enable = true,


### PR DESCRIPTION
- 新增用於 `noice.nvim` 插件設定的新 Lua 檔案
- 在 `noice.lua` 檔案中配置插件選項和依賴關係
- 在 `noice.lua` 檔案中註冊鍵映射以關閉 Noice 訊息
- 修改 `treesitter.lua` 檔案以包含 `regex` 語言以進行語法突出显示

Signed-off-by: HomePC <jackie@dast.tw>
