### PR TITLE
GIT 提交消息：

### DIFF
--- a/lua/dast/plugins/formatting.lua
+++ b/lua/dast/plugins/formatting.lua
@@ -8,7 +8,7 @@ return {
       formatters_by_ft = {
         markdown = { "prettier" },
         json = { "prettier" },
-        bash = { "shellcheck" },
+        bash = { "shfmt" },
         sh = { "shfmt" },
         yaml = { "prettier" },
         lua = { "stylua" },

--- a/lua/dast/plugins/lsp/lspconfig.lua
+++ b/lua/dast/plugins/lsp/lspconfig.lua
@@ -117,14 +117,6 @@ return {
           on_attach = on_attach,
         })
       end,
-      ["powershell_es"] = function()
-        -- configure powershell language server
-        lspconfig["powershell_es"].setup({
-          capabilities = capabilities,
-          filetypes = { "ps1" },
-          on_attach = on_attach,
-        })
-      end,
     })
   end,
 }

--- a/lua/dast/plugins/lsp/mason.lua
+++ b/lua/dast/plugins/lsp/mason.lua
@@ -30,7 +30,6 @@ return {
         "bashls",
         "lua_ls",
         "pyright",
-        "powershell_es",
       },
     })
 


### PR DESCRIPTION
重構：調整語言伺服器配置

- 將 `bash` 的格式化程序從 `shellcheck` 更改為 `shfmt`
- 從 `lspconfig.lua` 中刪除 `powershell_es` 語言伺服器的配置
- 從 `mason.lua` 中支持的語言伺服器列表中移除 `powershell_es`

Signed-off-by: HomePC <jackie@dast.tw>
