### PR TITLE
特性: 重構 ChatGPT 代碼補全的按鍵映射和設置

### DIFF
--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -12,6 +12,8 @@ return {
     require("chatgpt").setup({
       api_key_cmd = "gpg --decrypt " .. home .. "/openai.gpg",
     })
+    vim.keymap.set("n", "<Leader>cC", "<cmd>CHatGPTCompleteCode<CR>", { desc = "ChatGPT AutoComplete Code" })
+    vim.keymap.set("n", "<Leader>ct", "<cmd>ChatGPTRun add_tests<CR>", { desc = "ChatGPT Add Test Code" })
   end,
   keys = {
     { "<Leader>cc", "<cmd>ChatGPT<CR>", { desc = "Open ChatGPT" } },


### PR DESCRIPTION
- 新增 ChatGPT 代碼補全和測試代碼的按鍵映射
- 更新 `chatgpt.setup` 以包括新的按鍵映射 openai.gpg 解密指令

Signed-off-by: HomePC <jackie@dast.tw>
