### PR TITLE
功能：重新配置 ChatGPT 整合的鍵盤快捷鍵

### DIFF
--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -13,10 +13,8 @@ return {
     require("chatgpt").setup({
       api_key_cmd = "gpg --decrypt " .. home .. "/openai.gpg",
     })
+    vim.keymap.set("n", "<Leader>cc", "<cmd>ChatGPT<CR>", { desc = "Open ChatGPT" })
     vim.keymap.set("n", "<Leader>cm", "<cmd>CHatGPTCompleteCode<CR>", { desc = "ChatGPT AutoComplete Code" })
     vim.keymap.set("n", "<Leader>ct", "<cmd>ChatGPTRun add_tests<CR>", { desc = "ChatGPT Add Test Code" })
   end,
-  keys = {
-    { "<Leader>cc", "<cmd>ChatGPT<CR>", { desc = "Open ChatGPT" } },
-  },
 }


### PR DESCRIPTION
- 添加對`開啟 ChatGPT`的鍵盤映射
- 移除對`開啟 ChatGPT`的鍵盤映射

Signed-off-by: HomePC <jackie@dast.tw>
