### PR TITLE
特性: 重構源代碼插件配置檢索

### DIFF
--- a/lua/dast/plugins/substitute.lua
+++ b/lua/dast/plugins/substitute.lua
@@ -1,5 +1,6 @@
 return {
   "gbprod/substitute.nvim",
+  enabled = false,
   event = { "BufReadPre", "BufNewFile" },
   config = function()
     local substitute = require("substitute")


### PR DESCRIPTION
- 停用插件 `gbprod/substitute.nvim`
- 添加一行來將 `enabled` 設置為 `false`

Signed-off-by: HomePC <jackie@dast.tw>
