### PR TITLE
功能: 更新插件設定以增強功能

### DIFF
--- a/lua/dast/plugins/autopairs.lua
+++ b/lua/dast/plugins/autopairs.lua
@@ -16,7 +16,7 @@ return {
         javascript = { "template_string" }, -- don't add pairs in javscript template_string treesitter nodes
         java = false, -- don't check treesitter on java
         sh = false, -- enable autopairs in all shell script treesitter nodes
-        zsh = false,
+        python = false,
       },
     })
 

--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -33,11 +33,13 @@ return {
 
     require("chatgpt").setup(config)
   end,
+
   keys = {
     { "<Leader>cc", "<cmd>ChatGPT<CR>", desc = "Open ChatGPT" },
     { "<Leader>cm", "<cmd>ChatGPTCompleteCode<CR>", desc = "ChatGPT AutoComplete Code" },
     { "<Leader>ct", "<cmd>ChatGPTRun add_tests<CR>", desc = "ChatGPT Add Test Code" },
   },
+
   dependencies = {
     "MunifTanjim/nui.nvim",
     "nvim-lua/plenary.nvim",

--- a/lua/dast/plugins/nvim-cmp.lua
+++ b/lua/dast/plugins/nvim-cmp.lua
@@ -10,7 +10,7 @@ return {
       -- follow latest release.
       version = "v2.*", -- Replace <CurrentMajor> by the latest released major (first number of latest release)
       -- install jsregexp (optional!).
-      -- build = "zig init install_jsregexp",
+      build = "cmake install_jsregexp",
     },
     "saadparwaiz1/cmp_luasnip", -- for autocompletion
     "rafamadriz/friendly-snippets", -- useful snippets

--- a/lua/dast/plugins/telescope.lua
+++ b/lua/dast/plugins/telescope.lua
@@ -3,7 +3,7 @@ return {
   branch = "0.1.x",
   dependencies = {
     "nvim-lua/plenary.nvim",
-    { "nvim-telescope/telescope-fzf-native.nvim", build = "zig init" },
+    { "nvim-telescope/telescope-fzf-native.nvim", build = "cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build" },
     "nvim-tree/nvim-web-devicons",
     "folke/todo-comments.nvim",
   },
@@ -24,7 +24,7 @@ return {
       },
     })
 
-    -- telescope.load_extension("fzf")
+    telescope.load_extension("fzf")
     telescope.load_extension("noice")
     telescope.load_extension("notify")
 


### PR DESCRIPTION
- 在 `autopairs.lua` 中啟用 Python 的自動配對
- 在 `chatgpt.lua` 中添加 ChatGPT 插件的鍵綁定和依賴項
- 在 `nvim-cmp.lua` 中更改 jsregexp 的構建命令
- 在 `telescope.lua` 中更新 `telescope-fzf-native.nvim` 的構建過程
- 在 `telescope.lua` 中加載 Telescope 的擴展

Signed-off-by: HomePC <jackie@dast.tw>
