### PR TITLE
重構：在多個 Lua 檔案中將 `cond` 設置為 `false`

### DIFF
--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -1,7 +1,7 @@
 return {
   "jackMort/ChatGPT.nvim",
-  -- enabled = false,
-  config = function()
+  cond = false,
+  -- config = function()
     local home = vim.fn.expand("$HOME")
 
     local config = {

--- a/lua/dast/plugins/comment.lua
+++ b/lua/dast/plugins/comment.lua
@@ -1,6 +1,7 @@
 ---@diagnostic disable: missing-fields
 return {
   "numToStr/Comment.nvim",
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   dependencies = {
     "JoosepAlviste/nvim-ts-context-commentstring",

--- a/lua/dast/plugins/gitsigns.lua
+++ b/lua/dast/plugins/gitsigns.lua
@@ -1,5 +1,6 @@
 return {
   "lewis6991/gitsigns.nvim",
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   opts = {
     on_attach = function(bufnr)

--- a/lua/dast/plugins/lazygit.lua
+++ b/lua/dast/plugins/lazygit.lua
@@ -1,5 +1,6 @@
 return {
   "kdheepak/lazygit.nvim",
+  -- cond = false,
   cmd = {
     "LazyGit",
     "LazyGitConfig",

--- a/lua/dast/plugins/substitute.lua
+++ b/lua/dast/plugins/substitute.lua
@@ -1,6 +1,6 @@
 return {
   "gbprod/substitute.nvim",
-  -- enabled = false,
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   config = function()
     local substitute = require("substitute")

--- a/lua/dast/plugins/surround.lua
+++ b/lua/dast/plugins/surround.lua
@@ -1,5 +1,6 @@
 return {
   "kylechui/nvim-surround",
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   version = "*", -- Use for stability; omit to use `main` branch for the latest features
   config = true,

--- a/lua/dast/plugins/tabby.lua
+++ b/lua/dast/plugins/tabby.lua
@@ -1,5 +1,6 @@
 return {
   "nanozuki/tabby.nvim",
+  -- cond = false,
   event = "VimEnter",
   dependencies = "nvim-tree/nvim-web-devicons",
   config = function()

--- a/lua/dast/plugins/telescope.lua
+++ b/lua/dast/plugins/telescope.lua
@@ -3,7 +3,10 @@ return {
   branch = "0.1.x",
   dependencies = {
     "nvim-lua/plenary.nvim",
-    { "nvim-telescope/telescope-fzf-native.nvim", build = "cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build" },
+    {
+      "nvim-telescope/telescope-fzf-native.nvim",
+      build = "cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build",
+    },
     "nvim-tree/nvim-web-devicons",
     "folke/todo-comments.nvim",
   },

--- a/lua/dast/plugins/todo-comments.lua
+++ b/lua/dast/plugins/todo-comments.lua
@@ -1,5 +1,6 @@
 return {
   "folke/todo-comments.nvim",
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   dependencies = { "nvim-lua/plenary.nvim" },
   config = function()

--- a/lua/dast/plugins/trouble.lua
+++ b/lua/dast/plugins/trouble.lua
@@ -1,5 +1,6 @@
 return {
   "folke/trouble.nvim",
+  -- cond = false,
   dependencies = { "nvim-tree/nvim-web-devicons", "folke/todo-comments.nvim" },
   keys = {
     { "<leader>xx", "<cmd>TroubleToggle<CR>", desc = "Open/close trouble list" },

--- a/lua/dast/plugins/which-key.lua
+++ b/lua/dast/plugins/which-key.lua
@@ -1,5 +1,6 @@
 return {
   "folke/which-key.nvim",
+  -- cond = false,
   event = "VeryLazy",
   init = function()
     vim.o.timeout = true


### PR DESCRIPTION
- 修改 `chatgpt.lua` 以將 `cond` 設置為 `false`
- 在設置 `cond` 為 `false` 的 `comment.lua` 中刪除註釋
- 更新 `gitsigns.lua` 以將 `cond` 設置為 `false`
- 更新 `lazygit.lua` 以將 `cond` 設置為 `false`
- 在設置 `cond` 為 `false` 的 `substitute.lua` 中刪除註釋
- 更新 `surround.lua` 以將 `cond` 設置為 `false`
- 更新 `tabby.lua` 以將 `cond` 設置為 `false`
- 更新 `telescope.lua` 以格式化建置字段
- 在設置 `cond` 為 `false` 的 `todo-comments.lua` 中刪除註釋
- 更新 `trouble.lua` 以將 `cond` 設置為 `false`
- 更新 `which-key.lua` 以將 `cond` 設置為 `

Signed-off-by: HomePC <jackie@dast.tw>
