### PR TITLE
修復：更新 ChatGPT 開啟命令的快捷鍵設定

### DIFF
--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -35,7 +35,7 @@ return {
   end,
 
   keys = {
-    { "<Leader>cc", "<cmd>ChatGPT<CR>", desc = "Open ChatGPT" },
+    { "<Leader>cg", "<cmd>ChatGPT<CR>", desc = "Open ChatGPT" },
     { "<Leader>cm", "<cmd>ChatGPTCompleteCode<CR>", desc = "ChatGPT AutoComplete Code" },
     { "<Leader>ct", "<cmd>ChatGPTRun add_tests<CR>", desc = "ChatGPT Add Test Code" },
   },


### PR DESCRIPTION
- 將用於開啟 ChatGPT 的快捷鍵從「<Leader>cc」更改為「<Leader>cg」

Signed-off-by: HomePC <jackie@dast.tw>
