### PR TITLE
工具: 重構專案中的建構指令和相依性 - 在相依性中註解掉 `telescope-fzf-native.nvim` 的建構指令 - 修改 `lua/dast/plugins` 目錄中 `telescope.lua` 的相依性

### DIFF
--- a/lua/dast/plugins/telescope.lua
+++ b/lua/dast/plugins/telescope.lua
@@ -5,8 +5,8 @@ return {
   dependencies = {
     "nvim-lua/plenary.nvim",
     {
-      "nvim-telescope/telescope-fzf-native.nvim",
-      build = "zig build",
+      -- "nvim-telescope/telescope-fzf-native.nvim",
+      -- build = "zig build",
     },
     "nvim-tree/nvim-web-devicons",
     "folke/todo-comments.nvim",


### PR DESCRIPTION
Signed-off-by: OfficePC <jackie@dast.tw>
