### PR TITLE
feat: refactor file loading logic for neovim plugins

### DIFF
--- a/lua/dast/plugins/which-key.lua
+++ b/lua/dast/plugins/which-key.lua
@@ -1,26 +1,42 @@
 return {
-  "folke/which-key.nvim",
-  -- cond = false,
-  event = "VeryLazy",
-  init = function()
-    vim.o.timeout = true
-    vim.o.timeoutlen = 500
-    --BUG: conflicting keymaps "gc"
-    -- unmap gc keymap
-    vim.api.nvim_set_keymap("n", "gc", "", { noremap = true, silent = true })
-  end,
-  opts = {
-    -- your configuration comes here
-    -- or leave it empty to use the default settings
-    -- refer to the configuration section below
-  },
-  keys = {
-    {
-      "<leader>?",
-      function()
-        require("which-key").show({ global = false })
-      end,
-      desc = "Buffer Local Keymaps (which-key)",
+  {
+    "folke/which-key.nvim",
+    -- cond = false,
+    event = "VeryLazy",
+    init = function()
+      vim.o.timeout = true
+      vim.o.timeoutlen = 300
+      --BUG: conflicting keymaps "gc"
+      -- unmap gc keymap
+      vim.api.nvim_set_keymap("n", "gc", "", { noremap = true, silent = true })
+    end,
+    opts = {
+      -- your configuration comes here
+      -- or leave it empty to use the default settings
+      -- refer to the configuration section below
     },
+    keys = {
+      {
+        "<leader>?",
+        function()
+          require("which-key").show({ global = false })
+        end,
+        desc = "Buffer Local Keymaps (which-key)",
+      },
+    },
+  },
+  {
+    "echasnovski/mini.icons",
+    opts = {},
+    lazy = true,
+    specs = {
+      { "nvim-tree/nvim-web-devicons", enabled = false, optional = true },
+    },
+    init = function()
+      package.preload["nvim-web-devicons"] = function()
+        require("mini.icons").mock_nvim_web_devicons()
+        return package.loaded["nvim-web-devicons"]
+      end
+    end,
   },
 }


### PR DESCRIPTION
- Decrease the timeout length from `500` to `300`
- Add new configuration for invoking `nvim-web-devicons` inside `mini.icons`
- Introduce initialization logic for `echasnovski/mini.icons` plugin including dynamic loading of `nvim-web-devicons`

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
