### PR TITLE
GIT 提交信息:

### DIFF
--- a/lua/dast/plugins/bufferline.lua
+++ b/lua/dast/plugins/bufferline.lua
@@ -6,7 +6,6 @@ return {
   opts = {
     options = {
       mode = "tabs",
-      separator_style = "slant",
     },
   },
 }

--- a/lua/dast/plugins/colorscheme.lua
+++ b/lua/dast/plugins/colorscheme.lua
@@ -1,41 +1,46 @@
 ---@diagnostic disable: inject-field
 return {
-  {
-    "folke/tokyonight.nvim",
-    priority = 1000, -- make sure to load this before all the other start plugins
-    config = function()
-      local bg = "#011628"
-      local bg_dark = "#011423"
-      local bg_highlight = "#143652"
-      local bg_search = "#0A64AC"
-      local bg_visual = "#275378"
-      local fg = "#CBE0F0"
-      local fg_dark = "#B4D0E9"
-      local fg_gutter = "#627E97"
-      local border = "#547998"
+  "folke/tokyonight.nvim",
+  priority = 1000,
+  config = function()
+    local transparent = true -- set to true if you would like to enable transparency
 
-      require("tokyonight").setup({
-        style = "night",
-        on_colors = function(colors)
-          colors.bg = bg
-          colors.bg_dark = bg_dark
-          colors.bg_float = bg_dark
-          colors.bg_highlight = bg_highlight
-          colors.bg_popup = bg_dark
-          colors.bg_search = bg_search
-          colors.bg_sidebar = bg_dark
-          colors.bg_statusline = bg_dark
-          colors.bg_visual = bg_visual
-          colors.border = border
-          colors.fg = fg
-          colors.fg_dark = fg_dark
-          colors.fg_float = fg
-          colors.fg_gutter = fg_gutter
-          colors.fg_sidebar = fg_dark
-        end,
-      })
-      -- load the colorscheme here
-      vim.cmd([[colorscheme tokyonight]])
-    end,
-  },
+    local bg = "#011628"
+    local bg_dark = "#011423"
+    local bg_highlight = "#143652"
+    local bg_search = "#0A64AC"
+    local bg_visual = "#275378"
+    local fg = "#CBE0F0"
+    local fg_dark = "#B4D0E9"
+    local fg_gutter = "#627E97"
+    local border = "#547998"
+
+    require("tokyonight").setup({
+      style = "night",
+      transparent = transparent,
+      styles = {
+        sidebars = transparent and "transparent" or "dark",
+        floats = transparent and "transparent" or "dark",
+      },
+      on_colors = function(colors)
+        colors.bg = bg
+        colors.bg_dark = transparent and colors.none or bg_dark
+        colors.bg_float = transparent and colors.none or bg_dark
+        colors.bg_highlight = bg_highlight
+        colors.bg_popup = bg_dark
+        colors.bg_search = bg_search
+        colors.bg_sidebar = transparent and colors.none or bg_dark
+        colors.bg_statusline = transparent and colors.none or bg_dark
+        colors.bg_visual = bg_visual
+        colors.border = border
+        colors.fg = fg
+        colors.fg_dark = fg_dark
+        colors.fg_float = fg
+        colors.fg_gutter = fg_gutter
+        colors.fg_sidebar = fg_dark
+      end,
+    })
+
+    vim.cmd("colorscheme tokyonight")
+  end,
 }

--- a/lua/dast/plugins/nvim-tree.lua
+++ b/lua/dast/plugins/nvim-tree.lua
@@ -11,7 +11,7 @@ return {
     nvimtree.setup({
       view = {
         width = 35,
-        relativenumber = false,
+        relativenumber = true,
       },
       -- change folder arrow icons
       renderer = {

--- a/lua/dast/plugins/nvim-tressitter-textobjects.lua
+++ b/lua/dast/plugins/nvim-tressitter-textobjects.lua
@@ -1,0 +1,110 @@
+return {
+  "nvim-treesitter/nvim-treesitter-textobjects",
+  lazy = true,
+  config = function()
+    require("nvim-treesitter.configs").setup({
+      textobjects = {
+        select = {
+          enable = true,
+
+          -- Automatically jump forward to textobj, similar to targets.vim
+          lookahead = true,
+
+          keymaps = {
+            -- You can use the capture groups defined in textobjects.scm
+            ["a="] = { query = "@assignment.outer", desc = "Select outer part of an assignment" },
+            ["i="] = { query = "@assignment.inner", desc = "Select inner part of an assignment" },
+            ["l="] = { query = "@assignment.lhs", desc = "Select left hand side of an assignment" },
+            ["r="] = { query = "@assignment.rhs", desc = "Select right hand side of an assignment" },
+
+            -- works for javascript/typescript files (custom capture I created in after/queries/ecma/textobjects.scm)
+            ["a:"] = { query = "@property.outer", desc = "Select outer part of an object property" },
+            ["i:"] = { query = "@property.inner", desc = "Select inner part of an object property" },
+            ["l:"] = { query = "@property.lhs", desc = "Select left part of an object property" },
+            ["r:"] = { query = "@property.rhs", desc = "Select right part of an object property" },
+
+            ["aa"] = { query = "@parameter.outer", desc = "Select outer part of a parameter/argument" },
+            ["ia"] = { query = "@parameter.inner", desc = "Select inner part of a parameter/argument" },
+
+            ["ai"] = { query = "@conditional.outer", desc = "Select outer part of a conditional" },
+            ["ii"] = { query = "@conditional.inner", desc = "Select inner part of a conditional" },
+
+            ["al"] = { query = "@loop.outer", desc = "Select outer part of a loop" },
+            ["il"] = { query = "@loop.inner", desc = "Select inner part of a loop" },
+
+            ["af"] = { query = "@call.outer", desc = "Select outer part of a function call" },
+            ["if"] = { query = "@call.inner", desc = "Select inner part of a function call" },
+
+            ["am"] = { query = "@function.outer", desc = "Select outer part of a method/function definition" },
+            ["im"] = { query = "@function.inner", desc = "Select inner part of a method/function definition" },
+
+            ["ac"] = { query = "@class.outer", desc = "Select outer part of a class" },
+            ["ic"] = { query = "@class.inner", desc = "Select inner part of a class" },
+          },
+        },
+        swap = {
+          enable = true,
+          swap_next = {
+            ["<leader>na"] = "@parameter.inner", -- swap parameters/argument with next
+            ["<leader>n:"] = "@property.outer", -- swap object property with next
+            ["<leader>nm"] = "@function.outer", -- swap function with next
+          },
+          swap_previous = {
+            ["<leader>pa"] = "@parameter.inner", -- swap parameters/argument with prev
+            ["<leader>p:"] = "@property.outer", -- swap object property with prev
+            ["<leader>pm"] = "@function.outer", -- swap function with previous
+          },
+        },
+        move = {
+          enable = true,
+          set_jumps = true, -- whether to set jumps in the jumplist
+          goto_next_start = {
+            ["]f"] = { query = "@call.outer", desc = "Next function call start" },
+            ["]m"] = { query = "@function.outer", desc = "Next method/function def start" },
+            ["]c"] = { query = "@class.outer", desc = "Next class start" },
+            ["]i"] = { query = "@conditional.outer", desc = "Next conditional start" },
+            ["]l"] = { query = "@loop.outer", desc = "Next loop start" },
+
+            -- You can pass a query group to use query from `queries/<lang>/<query_group>.scm file in your runtime path.
+            -- Below example nvim-treesitter's `locals.scm` and `folds.scm`. They also provide highlights.scm and indent.scm.
+            ["]s"] = { query = "@scope", query_group = "locals", desc = "Next scope" },
+            ["]z"] = { query = "@fold", query_group = "folds", desc = "Next fold" },
+          },
+          goto_next_end = {
+            ["]F"] = { query = "@call.outer", desc = "Next function call end" },
+            ["]M"] = { query = "@function.outer", desc = "Next method/function def end" },
+            ["]C"] = { query = "@class.outer", desc = "Next class end" },
+            ["]I"] = { query = "@conditional.outer", desc = "Next conditional end" },
+            ["]L"] = { query = "@loop.outer", desc = "Next loop end" },
+          },
+          goto_previous_start = {
+            ["[f"] = { query = "@call.outer", desc = "Prev function call start" },
+            ["[m"] = { query = "@function.outer", desc = "Prev method/function def start" },
+            ["[c"] = { query = "@class.outer", desc = "Prev class start" },
+            ["[i"] = { query = "@conditional.outer", desc = "Prev conditional start" },
+            ["[l"] = { query = "@loop.outer", desc = "Prev loop start" },
+          },
+          goto_previous_end = {
+            ["[F"] = { query = "@call.outer", desc = "Prev function call end" },
+            ["[M"] = { query = "@function.outer", desc = "Prev method/function def end" },
+            ["[C"] = { query = "@class.outer", desc = "Prev class end" },
+            ["[I"] = { query = "@conditional.outer", desc = "Prev conditional end" },
+            ["[L"] = { query = "@loop.outer", desc = "Prev loop end" },
+          },
+        },
+      },
+    })
+
+    local ts_repeat_move = require("nvim-treesitter.textobjects.repeatable_move")
+
+    -- vim way: ; goes to the direction you were moving.
+    vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move)
+    vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_opposite)
+
+    -- Optionally, make builtin f, F, t, T also repeatable with ; and ,
+    vim.keymap.set({ "n", "x", "o" }, "f", ts_repeat_move.builtin_f)
+    vim.keymap.set({ "n", "x", "o" }, "F", ts_repeat_move.builtin_F)
+    vim.keymap.set({ "n", "x", "o" }, "t", ts_repeat_move.builtin_t)
+    vim.keymap.set({ "n", "x", "o" }, "T", ts_repeat_move.builtin_T)
+  end,
+}

--- a/lua/dast/plugins/substitute.lua
+++ b/lua/dast/plugins/substitute.lua
@@ -1,0 +1,17 @@
+return {
+  "gbprod/substitute.nvim",
+  event = { "BufReadPre", "BufNewFile" },
+  config = function()
+    local substitute = require("substitute")
+
+    substitute.setup()
+
+    -- set keymaps
+    local keymap = vim.keymap -- for conciseness
+
+    keymap.set("n", "s", substitute.operator, { desc = "Substitute with motion" })
+    keymap.set("n", "ss", substitute.line, { desc = "Substitute line" })
+    keymap.set("n", "S", substitute.eol, { desc = "Substitute to end of line" })
+    keymap.set("x", "s", substitute.visual, { desc = "Substitute in visual mode" })
+  end,
+}

--- a/lua/dast/plugins/telescope.lua
+++ b/lua/dast/plugins/telescope.lua
@@ -1,19 +1,26 @@
 return {
   "nvim-telescope/telescope.nvim",
-  event = "VeryLazy",
   branch = "0.1.x",
   dependencies = {
     "nvim-lua/plenary.nvim",
-    {
-      -- "nvim-telescope/telescope-fzf-native.nvim",
-      -- build = "zig build",
-    },
+    -- { "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
     "nvim-tree/nvim-web-devicons",
     "folke/todo-comments.nvim",
   },
   config = function()
     local telescope = require("telescope")
     local actions = require("telescope.actions")
+    local transform_mod = require("telescope.actions.mt").transform_mod
+
+    local trouble = require("trouble")
+    local trouble_telescope = require("trouble.sources.telescope")
+
+    -- or create your custom action
+    local custom_actions = transform_mod({
+      open_trouble_qflist = function(prompt_bufnr)
+        trouble.toggle("quickfix")
+      end,
+    })
 
     telescope.setup({
       defaults = {
@@ -22,7 +29,8 @@ return {
           i = {
             ["<C-k>"] = actions.move_selection_previous, -- move to prev result
             ["<C-j>"] = actions.move_selection_next, -- move to next result
-            ["<C-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
+            ["<C-q>"] = actions.send_selected_to_qflist + custom_actions.open_trouble_qflist,
+            ["<C-t>"] = trouble_telescope.open,
           },
         },
       },

--- a/lua/dast/plugins/trouble.lua
+++ b/lua/dast/plugins/trouble.lua
@@ -3,12 +3,15 @@ return {
   -- cond = false,
   event = "VeryLazy",
   dependencies = { "nvim-tree/nvim-web-devicons", "folke/todo-comments.nvim" },
+  opts = {
+    focus = true,
+  },
+  cmd = "Trouble",
   keys = {
-    { "<leader>xx", "<cmd>TroubleToggle<CR>", desc = "Open/close trouble list" },
-    { "<leader>xw", "<cmd>TroubleToggle workspace_diagnostics<CR>", desc = "Open trouble workspace diagnostics" },
-    { "<leader>xd", "<cmd>TroubleToggle document_diagnostics<CR>", desc = "Open trouble document diagnostics" },
-    { "<leader>xq", "<cmd>TroubleToggle quickfix<CR>", desc = "Open trouble quickfix list" },
-    { "<leader>xl", "<cmd>TroubleToggle loclist<CR>", desc = "Open trouble location list" },
-    { "<leader>xt", "<cmd>TodoTrouble<CR>", desc = "Open todos in trouble" },
+    { "<leader>xw", "<cmd>Trouble diagnostics toggle<CR>", desc = "Open trouble workspace diagnostics" },
+    { "<leader>xd", "<cmd>Trouble diagnostics toggle filter.buf=0<CR>", desc = "Open trouble document diagnostics" },
+    { "<leader>xq", "<cmd>Trouble quickfix toggle<CR>", desc = "Open trouble quickfix list" },
+    { "<leader>xl", "<cmd>Trouble loclist toggle<CR>", desc = "Open trouble location list" },
+    { "<leader>xt", "<cmd>Trouble todo toggle<CR>", desc = "Open todos in trouble" },
   },
 }


### PR DESCRIPTION
重构: 重新配置并优化多个插件之间的配置

- 删除 `bufferline.lua` 中的 `separator_style` 选项
- 调整 `colorscheme.lua` 中的优先级
- 更新 `nvim-tree.lua` 中与宽度相关的选项
- 添加 `nvim-treesitter-textobjects.lua` 的配置
- 添加 `substitute.lua` 插件的配置
- 在 `telescope.lua` 中更新插件依赖项和键映射
- 调整 `trouble.lua` 中的故障列表命令和焦点选项

Signed-off-by: OfficePC <jackie@dast.tw>
