### PR TITLE
feat: consolidate key mappings in Lua files

### DIFF
--- a/lua/dast/plugins/comment.lua
+++ b/lua/dast/plugins/comment.lua
@@ -18,4 +18,5 @@ return {
       pre_hook = ts_context_commentstring.create_pre_hook(),
     })
   end,
+  vim.api.nvim_set_keymap("n", "gc", "", { noremap = true, silent = true }),
 }

--- a/lua/dast/plugins/mini-icons.lua
+++ b/lua/dast/plugins/mini-icons.lua
@@ -1,0 +1,14 @@
+return {
+  "echasnovski/mini.icons",
+  opts = {},
+  lazy = true,
+  specs = {
+    { "nvim-tree/nvim-web-devicons", enabled = false, optional = true },
+  },
+  init = function()
+    package.preload["nvim-web-devicons"] = function()
+      require("mini.icons").mock_nvim_web_devicons()
+      return package.loaded["nvim-web-devicons"]
+    end
+  end,
+}

--- a/lua/dast/plugins/which-key.lua
+++ b/lua/dast/plugins/which-key.lua
@@ -1,42 +1,25 @@
 return {
-  {
-    "folke/which-key.nvim",
-    -- cond = false,
-    event = "VeryLazy",
-    init = function()
-      vim.o.timeout = true
-      vim.o.timeoutlen = 300
-      --BUG: conflicting keymaps "gc"
-      -- unmap gc keymap
-      vim.api.nvim_set_keymap("n", "gc", "", { noremap = true, silent = true })
-    end,
-    opts = {
-      -- your configuration comes here
-      -- or leave it empty to use the default settings
-      -- refer to the configuration section below
-    },
-    keys = {
-      {
-        "<leader>?",
-        function()
-          require("which-key").show({ global = false })
-        end,
-        desc = "Buffer Local Keymaps (which-key)",
-      },
-    },
+  "folke/which-key.nvim",
+  -- cond = false,
+  event = "VeryLazy",
+  init = function()
+    vim.o.timeout = true
+    vim.o.timeoutlen = 300
+    --BUG: conflicting keymaps "gc"
+    -- unmap gc keymap
+  end,
+  opts = {
+    -- your configuration comes here
+    -- or leave it empty to use the default settings
+    -- refer to the configuration section below
   },
-  {
-    "echasnovski/mini.icons",
-    opts = {},
-    lazy = true,
-    specs = {
-      { "nvim-tree/nvim-web-devicons", enabled = false, optional = true },
+  keys = {
+    {
+      "<leader>?",
+      function()
+        require("which-key").show({ global = false })
+      end,
+      desc = "Buffer Local Keymaps (which-key)",
     },
-    init = function()
-      package.preload["nvim-web-devicons"] = function()
-        require("mini.icons").mock_nvim_web_devicons()
-        return package.loaded["nvim-web-devicons"]
-      end
-    end,
   },
 }


### PR DESCRIPTION
- Add key mapping for `gc` in `comment.lua`
- Add a new file `mini-icons.lua` with initialization logic for different modules
- Remove key mapping for `gc` in `which-key.lua`

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
