### PR TITLE
chore: refactor Python language server configurations

### DIFF
--- a/lua/dast/plugins/lsp/formatting.lua
+++ b/lua/dast/plugins/lsp/formatting.lua
@@ -7,7 +7,7 @@ return {
     conform.setup({
       formatters_by_ft = {
         lua = { "stylua" },
-        python = { "isort", "black" },
+        python = { "black" },
         sh = { "shfmt" },
         bash = { "shfmt" },
         markdown = { "prettier" },

--- a/lua/dast/plugins/lsp/linting.lua
+++ b/lua/dast/plugins/lsp/linting.lua
@@ -5,7 +5,7 @@ return {
     local lint = require("lint")
 
     lint.linters_by_ft = {
-      python = { "pylint", "flake8", "mypy" },
+      python = { "pylint", "mypy" },
       bash = { "shellcheck" },
       sh = { "shellcheck" },
     }

--- a/lua/dast/plugins/lsp/mason.lua
+++ b/lua/dast/plugins/lsp/mason.lua
@@ -40,10 +40,8 @@ return {
         "shellcheck", --  ShellCheck, a static analysis tool for shell scripts.
         "pylint", -- Pylint is a static code analyser for Python 2 or 3.
         "stylua", -- An opinionated Lua code formatter.
-        "isort", -- isort is a Python utility / library to sort imports alphabetically.
         "shfmt", -- A shell formatter (sh/bash/mksh).
         "debugpy",
-        "flake8",
         "mypy",
       },
     })


### PR DESCRIPTION
- Remove `black` from the list of formatters for Python in `lua/dast/plugins/lsp/formatting.lua`
- Remove `flake8` from the list of linters for Python in `lua/dast/plugins/lsp/linting.lua`
- Remove `isort` and `flake8` from the list of tools in `lua/dast/plugins/lsp/mason.lua`

Signed-off-by: Macbook <jackie@dast.tw>
