### PR TITLE
chore: consolidate configuration options in settings

### DIFF
--- a/lua/dast/plugins/auto-session.lua
+++ b/lua/dast/plugins/auto-session.lua
@@ -12,6 +12,7 @@ return {
   opts = {
     auto_restore = false,
     bypass_save_filetypes = { "alpha", "dashboard" },
-    suppress_dirs = { "~/", "~/Downloads", "~/Documents", "~/Desktop/" },
+    allowed_dirs = { "~/Documents/github" },
+    suppress_dirs = { "~/", "~/Downloads", "~/Desktop/" },
   },
 }


### PR DESCRIPTION
- Add `allowed_dirs` configuration option with value `~/Documents/github`
- Modify `suppress_dirs` configuration option to exclude `~/Documents`

Signed-off-by: HomePC-WSL <jackie@dast.tw>
