### PR TITLE
chore: refactor file paths across the project

### DIFF
--- a/lua/dast/plugins/auto-session.lua
+++ b/lua/dast/plugins/auto-session.lua
@@ -12,7 +12,7 @@ return {
   opts = {
     auto_restore = false,
     bypass_save_filetypes = { "alpha", "dashboard" },
-    allowed_dirs = { "~/Documents/github" },
+    allowed_dirs = { "~/github" },
     suppress_dirs = { "~/", "~/Downloads", "~/Desktop/" },
   },
 }


### PR DESCRIPTION
- Update the `allowed_dirs` path from `~/Documents/github` to `~/github`

Signed-off-by: HomePC-WSL <jackie@dast.tw>
