### PR TITLE
fix: refactor code organization and dependency management

### DIFF
--- a/lua/dast/plugins/noice.lua
+++ b/lua/dast/plugins/noice.lua
@@ -14,10 +14,9 @@ return {
         override = {
           ["vim.lsp.util.convert_input_to_markdown_lines"] = true,
           ["vim.lsp.util.stylize_markdown"] = true,
-          ["cmp.entry.get_documentation"] = true, -- requires hrsh7th/nvim-cmp
+          ["cmp.entry.get_documentation"] = true,
         },
       },
-      -- you can enable a preset for easier configuration
       presets = {
         bottom_search = true, -- use a classic bottom cmdline for search
         command_palette = true, -- position the cmdline and popupmenu together
@@ -39,5 +38,6 @@ return {
   dependencies = {
     "MunifTanjim/nui.nvim",
     "rcarriga/nvim-notify",
+    "hrsh7th/nvim-cmp",
   },
 }


### PR DESCRIPTION
- Remove commented-out code for `cmp.entry.get_documentation`
- Add `hrsh7th/nvim-cmp` to the list of dependencies

Signed-off-by: HomePC-WSL <jackie@dast.tw>
